### PR TITLE
Update documents and libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,15 @@ To install this source,
 Plug 'tani/ddc-path',
 
 call ddc#custom#patch_global('sources', ['path'])
+call ddc#custom#patch_global('sourceOptions', {
+      \   'path': {'mark': 'P'},
+      \ })
 call ddc#custom#patch_global('sourceParams', {
-\   'path': { 'mark': 'P', 'cmd': ['fd', '--max-depth', '5'] } "or ['find', '-maxdepth', '5']
-\ })
+      \   'path': {
+      \     'cmd': ['fd', '--max-depth', '5'],
+      \   }
+      \ })
+      " or  'cmd': ['find', '-maxdepth', '5'],
 ```
 
 Copyright (c) 2021 TANIGUCHI Masaya. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Path completion for ddc.vim.
 This source collects path names with GNU find or sharkdp/fd.
 
-sharkdp/fd is a simple, fast and user-friendly alternative to 'find' .
+'sharkdp/fd' is a simple, fast and user-friendly alternative to 'find'.
 
 To install this source,
 

--- a/denops/@ddc-sources/path.ts
+++ b/denops/@ddc-sources/path.ts
@@ -4,12 +4,12 @@
  */
 import {
   BaseSource,
-  Candidate,
-} from "https://lib.deno.dev/x/ddc_vim@v0/types.ts";
+  DdcGatherItems,
+} from "https://deno.land/x/ddc_vim@v2.2.0/types.ts";
 import {
-  GatherCandidatesArguments,
+  GatherArguments,
   GetCompletePositionArguments,
-} from "https://lib.deno.dev/x/ddc_vim@v0/base/source.ts";
+} from "https://deno.land/x/ddc_vim@v2.2.0/base/source.ts";
 import * as fn from "https://deno.land/x/denops_std@v3.3.0/function/mod.ts";
 
 type UserData = Record<string, never>;
@@ -43,9 +43,10 @@ export class Source extends BaseSource<Params, UserData> {
     }
     return Promise.resolve(arg.context.input.length);
   }
-  override async gatherCandidates(
-    args: GatherCandidatesArguments<Params>,
-  ): Promise<Candidate<UserData>[]> {
+
+  override async gather(
+    args: GatherArguments<Params>,
+  ): Promise<DdcGatherItems<UserData>> {
     const decoder = new TextDecoder();
     const cwd = await fn.getcwd(args.denops) as string;
     const proc = Deno.run({
@@ -59,9 +60,9 @@ export class Source extends BaseSource<Params, UserData> {
     return text.split("\n").map((item) => ({
       word: `${cwd.trim()}/${item.trim().replace(/^\.\//, '')}`.replaceAll(" ", "\\ "),
       abbr: `${cwd.trim()}/${item.trim().replace(/^\.\//, '')}`,
-      mark: "path",
     }));
   }
+
   params(): Params {
     return {
       // cmd: ["fd", "--max-depth", "3"]

--- a/denops/@ddc-sources/path.ts
+++ b/denops/@ddc-sources/path.ts
@@ -10,7 +10,7 @@ import {
   GatherCandidatesArguments,
   GetCompletePositionArguments,
 } from "https://lib.deno.dev/x/ddc_vim@v0/base/source.ts";
-import * as fn from "https://deno.land/x/denops_std@v2.1.1/function/mod.ts";
+import * as fn from "https://deno.land/x/denops_std@v3.3.0/function/mod.ts";
 
 type UserData = Record<string, never>;
 type Params = {

--- a/doc/ddc-path.txt
+++ b/doc/ddc-path.txt
@@ -15,11 +15,18 @@ sharkdp/fd is a simple, fast and user-friendly alternative to 'find' .
 
 To install this source,
 >
-    Plug 'tani/ddc-path',
-    call ddc#custom#patch_global('sources', ['path'])
-    call ddc#custom#patch_global('sourceParams', {
-    \   'path': { 'mark': 'P', 'cmd': ['fd', '--max-depth', '5'] } "or ['find', '-maxdepth', '5']
-    \ })
+	Plug 'tani/ddc-path',
+
+	call ddc#custom#patch_global('sources', ['path'])
+	call ddc#custom#patch_global('sourceOptions', {
+	      \   'path': {'mark': 'P'},
+	      \ })
+	call ddc#custom#patch_global('sourceParams', {
+	      \   'path': {
+	      \     'cmd': ['fd', '--max-depth', '5'],
+	      \   }
+	      \ })
+	      " or  'cmd': ['find', '-maxdepth', '5'],
 <
 
 Copyright (c) 2021 TANIGUCHI Masaya. All rights reserved.

--- a/doc/ddc-path.txt
+++ b/doc/ddc-path.txt
@@ -1,22 +1,44 @@
-ddc-path.txt
+*ddc-path.txt*	Path completion for ddc.vim
 
-================================================================================
-CONTENTS                                                       *ddc-path-contents*
+Copyright (c) 2021 TANIGUCHI Masaya. All rights reserved.
 
-1. ddc-path....................................................|ddc-path-ddc-path|
+This work is licensed under the MIT license.
+git.io/mit-license
 
-================================================================================
-DDC-PATH                                                       *ddc-path-ddc-path*
+CONTENTS						*ddc-path-contents*
+
+Introduction	|ddc-path-introduction|
+Install		|ddc-path-install|
+Examples	|ddc-path-examples|
+Params		|ddc-path-params|
+
+
+==============================================================================
+INTRODUCTION						*ddc-path-introduction*
 
 Path completion for ddc.vim.
 This source collects path names with GNU find or sharkdp/fd.
 
-sharkdp/fd is a simple, fast and user-friendly alternative to 'find' .
+'sharkdp/fd' is a simple, fast and user-friendly alternative to 'find'.
 
-To install this source,
+
+==============================================================================
+INSTALL							*ddc-path-install*
+
+Please install both "ddc.vim" and "denops.vim".
+
+https://github.com/Shougo/ddc.vim
+https://github.com/vim-denops/denops.vim
+
+Use your preferred plugin manager.
 >
 	Plug 'tani/ddc-path',
+<
 
+==============================================================================
+EXAMPLES						*ddc-path-examples*
+
+>
 	call ddc#custom#patch_global('sources', ['path'])
 	call ddc#custom#patch_global('sourceOptions', {
 	      \   'path': {'mark': 'P'},
@@ -29,8 +51,15 @@ To install this source,
 	      " or  'cmd': ['find', '-maxdepth', '5'],
 <
 
-Copyright (c) 2021 TANIGUCHI Masaya. All rights reserved.
+==============================================================================
+PARAMS							*ddc-path-params*
 
-This work is licensed under the MIT license.
-git.io/mit-license
+							  *ddc-path-param-cmd*
+cmd		(string[])
+	An array of 'find' program arguments.
 
+	Default: ["find", "-maxdepth", "5"]
+
+
+==============================================================================
+vim:tw=78:ts=8:ft=help:norl:noet:fen:noet:


### PR DESCRIPTION
Fix documents:
- `mark` is parameter for `sourceOptions` instead `sourceParams`.
- Copying the example does not work. Because there is a comment in continuing line.
- Format help into a general form.

Update libraries to latest:
- denops_std v3.3.0
- ddc_vim v2.2.0